### PR TITLE
フロントデプロイ

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Check out
         uses: actions/checkout@v3
 
-      - name: Run
+      - name: Build
         run: |
           cd ./front && \
           npm install && \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           cd ./front && \
           npm install && \
-          npm run build
+          npm run production
 
       - name: Check
         run: ls -al ./front/build

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -3991,6 +3991,15 @@
         "yaml": "^1.10.0"
       }
     },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",

--- a/front/package.json
+++ b/front/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "production": "cross-env PUBLIC_URL=/golife react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
@@ -40,5 +41,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "cross-env": "^7.0.3"
   }
 }

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -75,9 +75,15 @@ function App() {
           </a>
         </h2>
         <p>
-          これはトップページです。↓で渡された初期状態に基づいて、各世代の世界を返します。
+          初期状態に基づいて、各世代の世界を返します。APIサーバ直アクセスの例↓
+          <pre>
+            curl -X POST -d $'Debug=trueGenCap=10&InitialWorld=●●○\n○○○\n○○○'
+            http://kd-golife.herokuapp.com/world/create
+          </pre>
         </p>
       </header>
+
+      <li>世界の縦横の幅が同じでないとバグる</li>
 
       <form>
         <label className="App-lb">初期世界 ●=生きている ○=死んでいる</label>
@@ -95,7 +101,7 @@ function App() {
         {history &&
           history.Worlds.map((world: World, i: number) => (
             <ul>
-              <li>{i}</li>
+              <li>{i}世代</li>
               {world["Cells"].map((cell: Cell, j: number) => (
                 <span>
                   {cell["IsLive"] ? LIVECHAR : DEADCHAR}


### PR DESCRIPTION
github pages ではルートディレクトリが/golife というようにリポジトリ名になる。ビルド成果物のパスが絶対パスを使っている場合jsファイルを解決できず、素のhtmlの真っ白画面になってしまう。